### PR TITLE
Push main to latest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,28 +5,27 @@ name: Sugoi API CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
-    - name: Upload war
-      uses: actions/upload-artifact@v2
-      with:
-        name: war
-        path: sugoi-api-services/target/*.war
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Upload war
+        uses: actions/upload-artifact@v2
+        with:
+          name: war
+          path: sugoi-api-services/target/*.war
 
   docker:
     needs: build
@@ -41,7 +40,7 @@ jobs:
           path: sugoi-api-services/target
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1.6.0
+        uses: crazy-max/ghaction-docker-meta@v1.8.4
         with:
           images: inseefrlab/sugoi-api # list of Docker images to use as base name for tags
       - name: Set up QEMU
@@ -60,7 +59,9 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+            ${{ github.ref == 'refs/heads/main' && 'inseefrlab/sugoi-api:latest' || '' }}
           labels: ${{ steps.docker_meta.outputs.labels }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Currently, the CI only pushes `main` to `main` tag on dockerhub.  
This PR adds `latest` tag for any commit on `main` branch.  

Sidenote : we should probably consider running CI `tags` also.