### PR TITLE
Fix file provider

### DIFF
--- a/sugoi-api-file-config-provider/pom.xml
+++ b/sugoi-api-file-config-provider/pom.xml
@@ -12,10 +12,25 @@
    <version>0.0.1-SNAPSHOT</version>
    <name>sugoi-api-file-config-provider</name>
    <dependencies>
+
+
       <dependency>
          <groupId>fr.insee.sugoi</groupId>
          <artifactId>sugoi-api-core</artifactId>
          <version>0.0.1-SNAPSHOT</version>
       </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-test</artifactId>
+         <scope>test</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>org.springframework.boot</groupId>
+               <artifactId>spring-boot-starter-logging</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
+
+
    </dependencies>
 </project>

--- a/sugoi-api-file-config-provider/src/test/java/fr/insee/sugoi/config/file/LocalFileRealmProviderDAO_realmsOneTest.java
+++ b/sugoi-api-file-config-provider/src/test/java/fr/insee/sugoi/config/file/LocalFileRealmProviderDAO_realmsOneTest.java
@@ -1,0 +1,50 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.config.file;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import fr.insee.sugoi.core.realm.RealmProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = LocalFileRealmProviderDAO.class)
+@TestPropertySource(
+    properties = "fr.insee.sugoi.realm.config.local.path=classpath:/realms-one.json")
+public class LocalFileRealmProviderDAO_realmsOneTest {
+
+  @Autowired RealmProvider localFileConfig;
+
+  @Test
+  public void shouldBeLocalFileRealmProvider() {
+    assertThat(
+        "RealmProvider should be an instance of LocalFileRealmProviderDAO",
+        localFileConfig,
+        isA(LocalFileRealmProviderDAO.class));
+  }
+
+  @Test
+  public void shouldHaveOnlyOneRealm() {
+    assertThat("There should be only one realm", localFileConfig.findAll().size(), is(1));
+  }
+
+  @Test
+  public void shouldFetchTestRealm() {
+    assertThat("We should have a realm test", localFileConfig.load("test").getName(), is("test"));
+    assertThat("We should have a realm TeSt", localFileConfig.load("TeSt").getName(), is("test"));
+  }
+}

--- a/sugoi-api-file-config-provider/src/test/java/fr/insee/sugoi/config/file/LocalFileRealmProviderDAO_realmsTwoTest.java
+++ b/sugoi-api-file-config-provider/src/test/java/fr/insee/sugoi/config/file/LocalFileRealmProviderDAO_realmsTwoTest.java
@@ -1,0 +1,50 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.config.file;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import fr.insee.sugoi.core.realm.RealmProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = LocalFileRealmProviderDAO.class)
+@TestPropertySource(
+    properties = "fr.insee.sugoi.realm.config.local.path=classpath:/realms-two.json")
+public class LocalFileRealmProviderDAO_realmsTwoTest {
+
+  @Autowired RealmProvider localFileConfig;
+
+  @Test
+  public void shouldBeLocalFileRealmProvider() {
+    assertThat(
+        "RealmProvider should be an instance of LocalFileRealmProviderDAO",
+        localFileConfig,
+        isA(LocalFileRealmProviderDAO.class));
+  }
+
+  @Test
+  public void shouldHaveTwoRealms() {
+    assertThat("There should be only one realm", localFileConfig.findAll().size(), is(2));
+  }
+
+  @Test
+  public void shouldFetchTestRealm() {
+    assertThat("We should have a realm test", localFileConfig.load("test").getName(), is("test"));
+    assertThat("We should have a realm TeSt", localFileConfig.load("TeSt").getName(), is("test"));
+  }
+}

--- a/sugoi-api-file-config-provider/src/test/resources/realms-one.json
+++ b/sugoi-api-file-config-provider/src/test/resources/realms-one.json
@@ -1,0 +1,17 @@
+[
+    {
+        "name": "test",
+        "url": "/test",
+        "appSource": "/applications",
+        "userStorages": [
+            {
+                "name": "default",
+                "userSource": "/users",
+                "organizationSource": "/organizations",
+                "properties": null,
+                "readerType": null,
+                "writerType": null
+            }
+        ]
+    }
+]

--- a/sugoi-api-file-config-provider/src/test/resources/realms-two.json
+++ b/sugoi-api-file-config-provider/src/test/resources/realms-two.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name": "test",
+        "url": "/test",
+        "appSource": "/applications",
+        "userStorages": [
+            {
+                "name": "default",
+                "userSource": "/users",
+                "organizationSource": "/organizations",
+                "properties": null,
+                "readerType": null,
+                "writerType": null
+            }
+        ]
+    },
+    {
+        "name": "test2",
+        "url": "/test",
+        "appSource": "/applications",
+        "userStorages": [
+            {
+                "name": "none",
+                "userSource": "/users",
+                "organizationSource": "/organizations",
+                "properties": null,
+                "readerType": null,
+                "writerType": null
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Realm list is fetched by `ResourceLoader`, this allows to use classic uri for files

Signed-off-by: Cédric Couralet <cedric.couralet@insee.fr>