### PR TITLE
Refactor search method with ldap mapper interface

### DIFF
--- a/sugoi-api-core/src/main/java/fr/insee/sugoi/core/store/ReaderStore.java
+++ b/sugoi-api-core/src/main/java/fr/insee/sugoi/core/store/ReaderStore.java
@@ -40,22 +40,25 @@ public interface ReaderStore {
       String rolePropriete,
       String certificat);
 
-  public PageResult<User> getUsersInGroup(String groupName);
+  public PageResult<User> getUsersInGroup(String appName, String groupName);
 
   public Organization getOrganization(String id);
 
-  public Organization searchOrganizations(
+  public PageResult<Organization> searchOrganizations(
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator);
 
-  public Group getGroup(String name);
+  public Group getGroup(String appName, String groupName);
 
   public PageResult<Group> searchGroups(
-      Map<String, String> searchProperties, PageableResult pageable, String searchOperator);
+      String appName,
+      Map<String, String> searchProperties,
+      PageableResult pageable,
+      String searchOperator);
 
   public boolean validateCredentials(User user, String credential);
 
   public Application getApplication(String applicationName);
 
-  public Application searchApplications(
+  public PageResult<Application> searchApplications(
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator);
 }

--- a/sugoi-api-core/src/main/java/fr/insee/sugoi/core/store/WriterStore.java
+++ b/sugoi-api-core/src/main/java/fr/insee/sugoi/core/store/WriterStore.java
@@ -26,11 +26,11 @@ public interface WriterStore {
 
   User updateUser(User updatedUser);
 
-  void deleteGroup(String name);
+  void deleteGroup(String appName, String groupName);
 
-  Group createGroup(Group group);
+  Group createGroup(String appName, Group group);
 
-  Group updateGroup(Group updatedGroup);
+  Group updateGroup(String appName, Group updatedGroup);
 
   void deleteOrganization(String organizationId);
 
@@ -44,9 +44,9 @@ public interface WriterStore {
 
   Organization updateOrganization(Organization updatedOrganization);
 
-  void deleteUserFromGroup(String groupName, String userId);
+  void deleteUserFromGroup(String appName, String groupName, String userId);
 
-  void addUserToGroup(String groupName, String userId);
+  void addUserToGroup(String appName, String groupName, String userId);
 
   void reinitPassword(User user);
 

--- a/sugoi-api-file-store-provider/src/main/java/fr/insee/sugoi/store/file/FileReaderStore.java
+++ b/sugoi-api-file-store-provider/src/main/java/fr/insee/sugoi/store/file/FileReaderStore.java
@@ -60,27 +60,30 @@ public class FileReaderStore implements ReaderStore {
   }
 
   @Override
-  public PageResult<User> getUsersInGroup(String groupName) {
+  public PageResult<User> getUsersInGroup(String appName, String groupName) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public Organization searchOrganizations(
+  public PageResult<Organization> searchOrganizations(
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public Group getGroup(String name) {
+  public Group getGroup(String appName, String groupName) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
   public PageResult<Group> searchGroups(
-      Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
+      String appName,
+      Map<String, String> searchProperties,
+      PageableResult pageable,
+      String searchOperator) {
     // TODO Auto-generated method stub
     return null;
   }
@@ -98,7 +101,7 @@ public class FileReaderStore implements ReaderStore {
   }
 
   @Override
-  public Application searchApplications(
+  public PageResult<Application> searchApplications(
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
     // TODO Auto-generated method stub
     return null;

--- a/sugoi-api-file-store-provider/src/main/java/fr/insee/sugoi/store/file/FileWriterStore.java
+++ b/sugoi-api-file-store-provider/src/main/java/fr/insee/sugoi/store/file/FileWriterStore.java
@@ -42,19 +42,19 @@ public class FileWriterStore implements WriterStore {
   }
 
   @Override
-  public void deleteGroup(String name) {
+  public void deleteGroup(String appName, String groupName) {
     // TODO Auto-generated method stub
 
   }
 
   @Override
-  public Group createGroup(Group group) {
+  public Group createGroup(String appName, Group appGroup) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public Group updateGroup(Group updatedGroup) {
+  public Group updateGroup(String appName, Group updatedGroup) {
     // TODO Auto-generated method stub
     return null;
   }
@@ -78,13 +78,13 @@ public class FileWriterStore implements WriterStore {
   }
 
   @Override
-  public void deleteUserFromGroup(String groupName, String userId) {
+  public void deleteUserFromGroup(String appName, String groupName, String userId) {
     // TODO Auto-generated method stub
 
   }
 
   @Override
-  public void addUserToGroup(String groupName, String userId) {
+  public void addUserToGroup(String appName, String groupName, String userId) {
     // TODO Auto-generated method stub
 
   }

--- a/sugoi-api-jms-store-provider/src/main/java/fr/insee/sugoi/jms/JmsWriterStore.java
+++ b/sugoi-api-jms-store-provider/src/main/java/fr/insee/sugoi/jms/JmsWriterStore.java
@@ -59,19 +59,19 @@ public class JmsWriterStore implements WriterStore {
   }
 
   @Override
-  public void deleteGroup(String name) {
+  public void deleteGroup(String appName, String groupName) {
     // TODO Auto-generated method stub
 
   }
 
   @Override
-  public Group createGroup(Group group) {
+  public Group createGroup(String appName, Group group) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public Group updateGroup(Group updatedGroup) {
+  public Group updateGroup(String appName, Group updatedGroup) {
     // TODO Auto-generated method stub
     return null;
   }
@@ -95,13 +95,13 @@ public class JmsWriterStore implements WriterStore {
   }
 
   @Override
-  public void deleteUserFromGroup(String groupName, String userId) {
+  public void deleteUserFromGroup(String appName, String groupName, String userId) {
     // TODO Auto-generated method stub
 
   }
 
   @Override
-  public void addUserToGroup(String groupName, String userId) {
+  public void addUserToGroup(String appName, String groupName, String userId) {
     // TODO Auto-generated method stub
 
   }

--- a/sugoi-api-ldap-store-provider/pom.xml
+++ b/sugoi-api-ldap-store-provider/pom.xml
@@ -14,6 +14,26 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-test</artifactId>
+         <scope>test</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>org.springframework.boot</groupId>
+               <artifactId>spring-boot-starter-logging</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-data-ldap</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>com.unboundid</groupId>
+         <artifactId>unboundid-ldapsdk</artifactId>
+      </dependency>
+      <dependency>
          <groupId>fr.insee.sugoi</groupId>
          <artifactId>sugoi-api-ldap-utils</artifactId>
       </dependency>

--- a/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapReaderStore.java
+++ b/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapReaderStore.java
@@ -29,6 +29,7 @@ import fr.insee.sugoi.ldap.utils.LdapUtils;
 import fr.insee.sugoi.ldap.utils.mapper.AddressLdapMapper;
 import fr.insee.sugoi.ldap.utils.mapper.ApplicationLdapMapper;
 import fr.insee.sugoi.ldap.utils.mapper.GroupLdapMapper;
+import fr.insee.sugoi.ldap.utils.mapper.LdapMapper;
 import fr.insee.sugoi.ldap.utils.mapper.OrganizationLdapMapper;
 import fr.insee.sugoi.ldap.utils.mapper.UserLdapMapper;
 import fr.insee.sugoi.model.Application;
@@ -66,17 +67,14 @@ public class LdapReaderStore implements ReaderStore {
   public User getUser(String id) {
     logger.debug("Searching user {}", id);
     SearchResultEntry entry = getEntryByDn("uid=" + id + "," + config.get("user_source"));
-    if (entry != null) {
-      return UserLdapMapper.mapFromSearchEntry(entry);
-    } else {
-      return null;
-    }
+    return (entry != null) ? (new UserLdapMapper()).fromLdapToObject(entry) : null;
   }
 
   @Override
   public Organization getOrganization(String id) {
     SearchResultEntry entry = getEntryByDn("uid=" + id + "," + config.get("organization_source"));
-    Organization org = (entry != null) ? OrganizationLdapMapper.mapFromSearchEntry(entry) : null;
+    Organization org =
+        (entry != null) ? (new OrganizationLdapMapper()).fromLdapToObject(entry) : null;
     if (org != null
         && org.getAttributes().containsKey("adressDn")
         && org.getAttributes().get("adressDn") != null) {
@@ -102,7 +100,6 @@ public class LdapReaderStore implements ReaderStore {
       String rolePropriete,
       String certificat) {
     try {
-      PageResult<User> page = new PageResult<>();
       Filter filter =
           LdapUtils.filterRechercher(
               typeRecherche,
@@ -114,18 +111,11 @@ public class LdapReaderStore implements ReaderStore {
               pageable,
               habilitations,
               certificat);
-      SearchRequest searchRequest =
+      return searchOnLdap(
           new SearchRequest(
-              config.get("user_source"), SearchScope.SUBORDINATE_SUBTREE, filter, "*", "+");
-      LdapUtils.setRequestControls(searchRequest, pageable);
-      SearchResult searchResult = ldapPoolConnection.search(searchRequest);
-      List<User> users =
-          searchResult.getSearchEntries().stream()
-              .map(e -> UserLdapMapper.mapFromSearchEntry(e))
-              .collect(Collectors.toList());
-      LdapUtils.setResponseControls(page, searchResult);
-      page.setResults(users);
-      return page;
+              config.get("user_source"), SearchScope.SUBORDINATE_SUBTREE, filter, "*", "+"),
+          pageable,
+          new UserLdapMapper());
     } catch (LDAPSearchException e) {
       throw new RuntimeException("Fail to execute user search", e);
     }
@@ -157,23 +147,30 @@ public class LdapReaderStore implements ReaderStore {
     return page;
   }
 
+  private <ResultType> PageResult<ResultType> searchOnLdap(
+      SearchRequest searchRequest, PageableResult pageableResult, LdapMapper<ResultType> mapper)
+      throws LDAPSearchException {
+    LdapUtils.setRequestControls(searchRequest, pageableResult);
+    SearchResult searchResult = ldapPoolConnection.search(searchRequest);
+    PageResult<ResultType> pageResult = new PageResult<>();
+    List<ResultType> results =
+        searchResult.getSearchEntries().stream()
+            .map(e -> mapper.fromLdapToObject(e))
+            .collect(Collectors.toList());
+    pageResult.setResults(results);
+    return pageResult;
+  }
+
   @Override
   public PageResult<Organization> searchOrganizations(
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
     Filter filter = LdapUtils.getFilterFromCriteria(searchProperties);
     try {
-      SearchRequest searchRequest =
+      return searchOnLdap(
           new SearchRequest(
-              config.get("organization_source"), SearchScope.SUBORDINATE_SUBTREE, filter, "*", "+");
-      LdapUtils.setRequestControls(searchRequest, pageable);
-      SearchResult searchResult = ldapPoolConnection.search(searchRequest);
-      List<Organization> organizations =
-          searchResult.getSearchEntries().stream()
-              .map(e -> OrganizationLdapMapper.mapFromSearchEntry(e))
-              .collect(Collectors.toList());
-      PageResult<Organization> page = new PageResult<>();
-      page.setResults(organizations);
-      return page;
+              config.get("organization_source"), SearchScope.SUBORDINATE_SUBTREE, filter, "*", "+"),
+          pageable,
+          new OrganizationLdapMapper());
     } catch (LDAPSearchException e) {
       throw new RuntimeException("Fail to search organizations in ldap", e);
     }
@@ -182,7 +179,7 @@ public class LdapReaderStore implements ReaderStore {
   @Override
   public Group getGroup(String appName, String groupName) {
     SearchResultEntry entry = getGroupResultEntry(appName, groupName);
-    return (entry != null) ? GroupLdapMapper.mapFromSearchEntry(entry) : null;
+    return (entry != null) ? (new GroupLdapMapper()).fromLdapToObject(entry) : null;
   }
 
   private SearchResultEntry getGroupResultEntry(String appName, String groupName) {
@@ -217,22 +214,15 @@ public class LdapReaderStore implements ReaderStore {
     Filter filter =
         Filter.createANDFilter(LdapUtils.getFilterFromCriteria(searchProperties), isGroup);
     try {
-      SearchRequest searchRequest =
+      return searchOnLdap(
           new SearchRequest(
               "ou=" + appName + "," + config.get("app_source"),
               SearchScope.SUBORDINATE_SUBTREE,
               filter,
               "*",
-              "+");
-      LdapUtils.setRequestControls(searchRequest, pageable);
-      SearchResult searchResult = ldapPoolConnection.search(searchRequest);
-      List<Group> groups =
-          searchResult.getSearchEntries().stream()
-              .map(e -> GroupLdapMapper.mapFromSearchEntry(e))
-              .collect(Collectors.toList());
-      PageResult<Group> page = new PageResult<>();
-      page.setResults(groups);
-      return page;
+              "+"),
+          pageable,
+          new GroupLdapMapper());
     } catch (LDAPSearchException e) {
       throw new RuntimeException("Fail to search groups in ldap", e);
     }
@@ -248,7 +238,7 @@ public class LdapReaderStore implements ReaderStore {
   public Application getApplication(String applicationName) {
     SearchResultEntry entry =
         getEntryByDn("ou=" + applicationName + "," + config.get("app_source"));
-    return (entry != null) ? ApplicationLdapMapper.mapFromSearchEntry(entry) : null;
+    return (entry != null) ? (new ApplicationLdapMapper()).fromLdapToObject(entry) : null;
   }
 
   @Override
@@ -256,17 +246,10 @@ public class LdapReaderStore implements ReaderStore {
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
     Filter filter = LdapUtils.getFilterFromCriteria(searchProperties);
     try {
-      SearchRequest searchRequest =
-          new SearchRequest(config.get("app_source"), SearchScope.ONE, filter, "*", "+");
-      LdapUtils.setRequestControls(searchRequest, pageable);
-      SearchResult searchResult = ldapPoolConnection.search(searchRequest);
-      List<Application> applications =
-          searchResult.getSearchEntries().stream()
-              .map(e -> ApplicationLdapMapper.mapFromSearchEntry(e))
-              .collect(Collectors.toList());
-      PageResult<Application> page = new PageResult<>();
-      page.setResults(applications);
-      return page;
+      return searchOnLdap(
+          new SearchRequest(config.get("app_source"), SearchScope.ONE, filter, "*", "+"),
+          pageable,
+          new ApplicationLdapMapper());
     } catch (LDAPSearchException e) {
       throw new RuntimeException("Fail to search applications in ldap", e);
     }

--- a/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapReaderStore.java
+++ b/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapReaderStore.java
@@ -21,7 +21,6 @@ import com.unboundid.ldap.sdk.SearchRequest;
 import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SearchScope;
-import fr.insee.sugoi.core.exceptions.EntityNotFoundException;
 import fr.insee.sugoi.core.model.PageResult;
 import fr.insee.sugoi.core.model.PageableResult;
 import fr.insee.sugoi.core.store.ReaderStore;
@@ -63,7 +62,11 @@ public class LdapReaderStore implements ReaderStore {
   public User getUser(String id) {
     logger.debug("Searching user {}", id);
     SearchResultEntry entry = getEntryByDn("uid=" + id + "," + config.get("user_source"));
-    return UserLdapMapper.mapFromSearchEntry(entry);
+    if (entry != null) {
+      return UserLdapMapper.mapFromSearchEntry(entry);
+    } else {
+      return null;
+    }
   }
 
   @Override
@@ -128,7 +131,7 @@ public class LdapReaderStore implements ReaderStore {
 
       return entry;
     } catch (LDAPException e) {
-      throw new EntityNotFoundException("Entry not found");
+      throw new RuntimeException("Failed to execute " + dn, e);
     }
   }
 

--- a/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapReaderStore.java
+++ b/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapReaderStore.java
@@ -133,27 +133,30 @@ public class LdapReaderStore implements ReaderStore {
   }
 
   @Override
-  public PageResult<User> getUsersInGroup(String groupName) {
+  public PageResult<User> getUsersInGroup(String appName, String groupName) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public Organization searchOrganizations(
+  public PageResult<Organization> searchOrganizations(
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public Group getGroup(String name) {
+  public Group getGroup(String appName, String name) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
   public PageResult<Group> searchGroups(
-      Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
+      String appName,
+      Map<String, String> searchProperties,
+      PageableResult pageable,
+      String searchOperator) {
     // TODO Auto-generated method stub
     return null;
   }
@@ -171,7 +174,7 @@ public class LdapReaderStore implements ReaderStore {
   }
 
   @Override
-  public Application searchApplications(
+  public PageResult<Application> searchApplications(
       Map<String, String> searchProperties, PageableResult pageable, String searchOperator) {
     // TODO Auto-generated method stub
     return null;

--- a/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapWriterStore.java
+++ b/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapWriterStore.java
@@ -63,19 +63,19 @@ public class LdapWriterStore implements WriterStore {
   }
 
   @Override
-  public void deleteGroup(String name) {
+  public void deleteGroup(String appName, String groupName) {
     // TODO Auto-generated method stub
 
   }
 
   @Override
-  public Group createGroup(Group group) {
+  public Group createGroup(String appName, Group group) {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public Group updateGroup(Group updatedGroup) {
+  public Group updateGroup(String appName, Group updatedGroup) {
     // TODO Auto-generated method stub
     return null;
   }
@@ -99,13 +99,13 @@ public class LdapWriterStore implements WriterStore {
   }
 
   @Override
-  public void deleteUserFromGroup(String groupName, String userId) {
+  public void deleteUserFromGroup(String appName, String groupName, String userId) {
     // TODO Auto-generated method stub
 
   }
 
   @Override
-  public void addUserToGroup(String groupName, String userId) {
+  public void addUserToGroup(String appName, String groupName, String userId) {
     // TODO Auto-generated method stub
 
   }

--- a/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapReaderStoreTest.java
+++ b/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapReaderStoreTest.java
@@ -1,0 +1,58 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap;
+
+import fr.insee.sugoi.model.Realm;
+import fr.insee.sugoi.model.UserStorage;
+import fr.insee.sugoi.store.ldap.LdapStoreBeans;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.ldap.embedded.EmbeddedLdapAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {EmbeddedLdapAutoConfiguration.class, LdapStoreBeans.class})
+@TestPropertySource(locations = "classpath:/application.properties")
+public class LdapReaderStoreTest {
+
+  @Value("${fr.insee.sugoi.ldap.default.organizationsource:}")
+  private String organizationSource;
+
+  @Value("${fr.insee.sugoi.ldap.default.appsource:}")
+  private String appSource;
+
+  @Value("${fr.insee.sugoi.ldap.default.usersource:}")
+  private String userSource;
+
+  @Bean
+  public UserStorage userStorage() {
+    UserStorage us = new UserStorage();
+    us.setOrganizationSource(organizationSource);
+    us.setUserSource(userSource);
+    us.setName("default");
+    return us;
+  }
+
+  @Bean(name = "Realm")
+  public Realm realm() {
+    Realm realm = new Realm();
+    realm.setName("domaine1");
+    realm.setUrl("localhost");
+    return realm;
+  }
+
+  @Autowired ApplicationContext context;
+}

--- a/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
+++ b/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import fr.insee.sugoi.model.Organization;
 import fr.insee.sugoi.model.Realm;
 import fr.insee.sugoi.model.User;
 import fr.insee.sugoi.model.UserStorage;
@@ -64,6 +65,48 @@ public class LdapWriterStoreTest {
   }
 
   @Autowired ApplicationContext context;
+
+  @Test
+  public void testCreateOrganization() {
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Organization organization = new Organization();
+    organization.setIdentifiant("Titi");
+    organization.addAttributes("description", "titi le test");
+    ldapWriterStore.createOrganization(organization);
+    assertThat(
+        "Titi should have been added", ldapReaderStore.getOrganization("Titi"), not(nullValue()));
+  }
+
+  @Test
+  public void testUpdateOrganizationDescription() {
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Organization organization = ldapReaderStore.getOrganization("amodifier");
+    organization.addAttributes("description", "nouvelle description");
+    ldapWriterStore.updateOrganization(organization);
+    assertThat(
+        "amodifier should have a new description",
+        ldapReaderStore.getOrganization("amodifier").getAttributes().get("description"),
+        is("nouvelle description"));
+  }
+
+  @Test
+  public void testDeleteOrganization() {
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    ldapWriterStore.deleteOrganization("asupprimer");
+    assertThat(
+        "asupprimer should have been deleted",
+        ldapReaderStore.getOrganization("asupprimer"),
+        is(nullValue()));
+  }
 
   @Test
   public void testCreateUser() {

--- a/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
+++ b/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import fr.insee.sugoi.model.Application;
 import fr.insee.sugoi.model.Organization;
 import fr.insee.sugoi.model.Realm;
 import fr.insee.sugoi.model.User;
@@ -61,6 +62,7 @@ public class LdapWriterStoreTest {
     Realm realm = new Realm();
     realm.setName("domaine1");
     realm.setUrl("localhost");
+    realm.setAppSource(appSource);
     return realm;
   }
 
@@ -147,5 +149,53 @@ public class LdapWriterStoreTest {
     ldapWriterStore.deleteUser("byebye");
     assertThat(
         "testc should have been deleted", ldapReaderStore.getUser("byebye"), is(nullValue()));
+  }
+
+  @Test
+  public void testCreateApplication() {
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Application application = new Application();
+    application.setName("MyApplication");
+    application.setOwner("Mine");
+    ldapWriterStore.createApplication(application);
+    assertThat(
+        "MyApplication should have been added",
+        ldapReaderStore.getApplication("MyApplication"),
+        not(nullValue()));
+  }
+
+  @Test
+  public void testUpdateApplicationOwner() {
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Application application = ldapReaderStore.getApplication("Applitest");
+    application.setOwner("Mine");
+    ldapWriterStore.updateApplication(application);
+    assertThat(
+        "Applitest should have a new owner",
+        ldapReaderStore.getApplication("Applitest").getOwner(),
+        is("Mine"));
+  }
+
+  @Test
+  public void testDeleteApplication() {
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Application application = new Application();
+    application.setName("EmptyApplication");
+    application.setOwner("Mine");
+    ldapWriterStore.createApplication(application);
+    ldapWriterStore.deleteApplication("EmptyApplication");
+    assertThat(
+        "EmptyApplication should have been deleted",
+        ldapReaderStore.getApplication("EmptyApplication"),
+        is(nullValue()));
   }
 }

--- a/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
+++ b/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import fr.insee.sugoi.model.Application;
+import fr.insee.sugoi.model.Group;
 import fr.insee.sugoi.model.Organization;
 import fr.insee.sugoi.model.Realm;
 import fr.insee.sugoi.model.User;
@@ -26,6 +27,8 @@ import fr.insee.sugoi.model.UserStorage;
 import fr.insee.sugoi.store.ldap.LdapReaderStore;
 import fr.insee.sugoi.store.ldap.LdapStoreBeans;
 import fr.insee.sugoi.store.ldap.LdapWriterStore;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -197,5 +200,110 @@ public class LdapWriterStoreTest {
         "EmptyApplication should have been deleted",
         ldapReaderStore.getApplication("EmptyApplication"),
         is(nullValue()));
+  }
+
+  @Test
+  public void testCreateGroup() {
+    // for now groups are not created with their users
+    // plus they are always created at the route of app_source
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Group group = new Group();
+    group.setName("Groupy");
+    group.setDescription("Super groupy de test");
+    User user = new User();
+    user.setUsername("usery");
+    List<User> users = new ArrayList<>();
+    users.add(user);
+    group.setUsers(users);
+    ldapWriterStore.createGroup("Applitest", group);
+    assertThat(
+        "Should retrieve Groupy",
+        ldapReaderStore.getGroup("Applitest", "Groupy").getName(),
+        is("Groupy"));
+  }
+
+  @Test
+  public void testDeleteGroup() {
+    // can only delete first sub tree groups
+    // TODO
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Group group = new Group();
+    group.setName("Asupprimer");
+    group.setDescription("supprime ce groupe");
+    ldapWriterStore.createGroup("Applitest", group);
+    ldapWriterStore.deleteGroup("Applitest", "Asupprimer");
+    assertThat(
+        "Should have been deleted",
+        ldapReaderStore.getGroup("Applitest", "Asupprimer"),
+        is(nullValue()));
+  }
+
+  @Test
+  public void testAddUserInGroup() {
+    // we can only update first sub tree group
+    // TODO
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    ldapWriterStore.addUserToGroup("Applitest", "SuperGroup", "testc");
+    assertThat(
+        "Group should contain testc",
+        ldapReaderStore.getUsersInGroup("Applitest", "SuperGroup").getResults().stream()
+            .anyMatch(user -> user.getUsername().equals("testc")));
+  }
+
+  @Test
+  public void testDeleteUserInGroup() {
+    // we can only update first sub tree group
+    // TODO
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    assertThat(
+        "Group should be empty",
+        ldapReaderStore.getUsersInGroup("Applitest", "SuperGroup").getResults().size(),
+        is(0));
+    ldapWriterStore.addUserToGroup("Applitest", "SuperGroup", "agarder");
+    ldapWriterStore.addUserToGroup("Applitest", "SuperGroup", "asupprimer");
+    ldapWriterStore.deleteUserFromGroup("Applitest", "SuperGroup", "asupprimer");
+    assertThat(
+        "Group should not contain asupprimer",
+        ldapReaderStore.getUsersInGroup("Applitest", "SuperGroup").getResults().stream()
+            .allMatch(
+                user ->
+                    user == null
+                        || user.getUsername() == null
+                        || !user.getUsername().equals("asupprimer")));
+    assertThat(
+        "Group should contain agarder",
+        ldapReaderStore.getUsersInGroup("Applitest", "SuperGroup").getResults().stream()
+            .anyMatch(
+                user ->
+                    user != null
+                        && user.getUsername() != null
+                        && user.getUsername().equals("agarder")));
+  }
+
+  @Test
+  public void testUpdateGroup() {
+    LdapWriterStore ldapWriterStore =
+        (LdapWriterStore) context.getBean("LdapWriterStore", realm(), userStorage());
+    LdapReaderStore ldapReaderStore =
+        (LdapReaderStore) context.getBean("LdapReaderStore", realm(), userStorage());
+    Group group = ldapReaderStore.getGroup("Applitest", "SuperGroup");
+    group.setDescription("new description");
+    ldapWriterStore.updateGroup("Applitest", group);
+    assertThat(
+        "SuperGroup description should be new description",
+        ldapReaderStore.getGroup("Applitest", "SuperGroup").getDescription(),
+        is("new description"));
   }
 }

--- a/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
+++ b/sugoi-api-ldap-store-provider/src/test/java/fr/insee/sugoi/ldap/LdapWriterStoreTest.java
@@ -1,0 +1,58 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap;
+
+import fr.insee.sugoi.model.Realm;
+import fr.insee.sugoi.model.UserStorage;
+import fr.insee.sugoi.store.ldap.LdapStoreBeans;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.ldap.embedded.EmbeddedLdapAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {EmbeddedLdapAutoConfiguration.class, LdapStoreBeans.class})
+@TestPropertySource(locations = "classpath:/application.properties")
+public class LdapWriterStoreTest {
+
+  @Value("${fr.insee.sugoi.ldap.default.organizationsource:}")
+  private String organizationSource;
+
+  @Value("${fr.insee.sugoi.ldap.default.appsource:}")
+  private String appSource;
+
+  @Value("${fr.insee.sugoi.ldap.default.usersource:}")
+  private String userSource;
+
+  @Bean
+  public UserStorage userStorage() {
+    UserStorage us = new UserStorage();
+    us.setOrganizationSource(organizationSource);
+    us.setUserSource(userSource);
+    us.setName("default");
+    return us;
+  }
+
+  @Bean(name = "Realm")
+  public Realm realm() {
+    Realm realm = new Realm();
+    realm.setName("domaine1");
+    realm.setUrl("localhost");
+    return realm;
+  }
+
+  @Autowired ApplicationContext context;
+}

--- a/sugoi-api-ldap-store-provider/src/test/resources/application.properties
+++ b/sugoi-api-ldap-store-provider/src/test/resources/application.properties
@@ -1,0 +1,15 @@
+spring.ldap.embedded.base-dn=o=insee,c=fr
+spring.ldap.embedded.ldif=classpath:ldap.ldif
+spring.ldap.embedded.validation.enabled=false
+spring.ldap.embedded.port=${fr.insee.sugoi.ldap.default.port}
+spring.ldap.embedded.credential.password=${fr.insee.sugoi.ldap.default.password}
+spring.ldap.embedded.credential.username=${fr.insee.sugoi.ldap.default.username}
+
+logging.level.root=debug
+fr.insee.sugoi.ldap.default.pool=10
+fr.insee.sugoi.ldap.default.usersource=ou=contacts,ou=clients_domaine1,o=insee,c=fr
+fr.insee.sugoi.ldap.default.organizationsource=ou=organisations,ou=clients_domaine1,o=insee,c=fr
+fr.insee.sugoi.ldap.default.appsource=ou=Applications,o=insee,c=fr
+fr.insee.sugoi.ldap.default.username=cn=admin,o=insee,c=fr
+fr.insee.sugoi.ldap.default.password=password
+fr.insee.sugoi.ldap.default.port=10389

--- a/sugoi-api-ldap-store-provider/src/test/resources/ldap.ldif
+++ b/sugoi-api-ldap-store-provider/src/test/resources/ldap.ldif
@@ -1,0 +1,404 @@
+# RACINE
+dn: o=insee,c=fr
+objectclass: top
+objectclass: organization
+o: insee
+
+
+# BRANCHE APPLICATION
+dn: ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: organizationalUnit
+ou: applications
+
+
+# BRANCHE APPLICATIVE APPLI TEST
+dn: ou=Applitest,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: organizationalUnit
+ou: Applitest
+description: Branche privative de l'application applitest
+
+dn: uid=appli_applitest,ou=Applitest,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+objectclass: inseeApplication
+cn: appli_applitest
+sn: appli_applitest
+givenname: appli_applitest
+uid: appli_applitest
+userpassword: applitest
+
+dn: cn=SuperGroup,ou=Applitest,ou=Applications,o=insee,c=fr
+cn: SuperGroup
+objectclass: groupOfUniqueNames
+
+dn: ou=Applitest_Objets,ou=Applitest,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: organizationalUnit
+ou: Applitest_Objets
+
+dn: cn=Administrateurs_Applitest,ou=Applitest_Objets,ou=Applitest,ou=Applications,o=insee,c=fr
+cn: Administrateurs_Applitest
+objectclass: groupOfUniqueNames
+
+dn: cn=Utilisateurs_Applitest,ou=Applitest_Objets,ou=Applitest,ou=Applications,o=insee,c=fr
+cn: Utilisateurs_Applitest
+objectclass: groupOfUniqueNames
+uniquemember: uid=Testd,ou=SSM,o=insee,c=fr
+uniquemember: uid=testc,ou=contacts,ou=clients_domaine1,o=insee,c=fr
+
+# BRANCHE APPLICATIVE WEB SERVICE
+dn: ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: organizationalUnit
+ou: WebServicesLdap
+description: Branche privative de l'application WebServicesLdap
+
+dn: uid=appli_WebServicesLdap,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+objectclass: inseeApplication
+cn: WebServicesLdap
+sn: WebServicesLdap
+givenname: WebServicesLdap
+uid: appli_WebServicesLdap
+userpassword: webservices
+
+dn: ou=WebServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: organizationalUnit
+ou: WebServicesLdap_Objets
+description: Objets privatifs de l'application WebServicesLdap
+
+dn: cn=Administrateurs_WebServicesLdap,ou=WebServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+description: Administrateurs généraux du WS gestion des contacts
+cn: Administrateurs_WebServicesLdap
+objectclass: top
+objectclass: groupOfUniqueNames
+uniquemember: uid=appli_webservicesldap,ou=Webservicesldap,ou=Applications,o=insee,c=fr
+
+dn: cn=Utilisateurs_contacts_domaine2_WebServicesLdap,ou=WebServicesLdap_Obje
+ ts,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+description: Utilisateur du webservices contact(champ de gestion SERV2010)
+cn: Utilisateurs_contacts_domaine2_WebServicesLdap
+objectclass: groupOfUniqueNames
+
+dn: cn=profil-contact-WebServicesLdap,ou=WebServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+cn: profil-contact-WebServicesLdap
+objectclass: inseeOrganizationalRole
+
+dn: cn=Profil_domaine2_WebServiceLdap,cn=profil-contact-WebServicesLdap,ou=We
+ bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+cn: Profil_domaine2_WebServiceLdap
+objectclass: inseeOrganizationalRole
+inseepropriete: ldapUrl$localhost
+inseepropriete: ldapPort$10389
+inseepropriete: brancheContact$ou=contacts,ou=clients_domaine2,o=insee,c=fr
+inseepropriete: brancheAdresse$ou=adresses,ou=clients_domaine2,o=insee,c=fr
+inseepropriete: brancheOrganisation$ou=organisations,ou=clients_domaine2,o=in
+ see,c=fr
+description: domaine2
+
+dn: cn=Profil_domaine1_WebServiceLdap,cn=profil-contact-WebServicesLdap,ou=We
+ bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+cn: Profil_domaine1_WebServiceLdap
+objectclass: inseeOrganizationalRole
+inseepropriete: ldapUrl$localhost
+inseepropriete: ldapPort$10389
+inseepropriete: brancheContact$ou=contacts,ou=clients_domaine1,o=insee,c=fr
+inseepropriete: brancheAdresse$ou=adresses,ou=clients_domaine1,o=insee,c=fr
+inseepropriete: brancheOrganisation$ou=organisations,ou=clients_domaine1,o=in
+ see,c=fr
+inseepropriete: habilitationsPossibles$propriete_role_appli
+inseepropriete: branchesApplicativesPossibles$applitest
+description: domaine1
+
+dn: cn=Utilisateurs_contacts_domaine1_WebServicesLdap,ou=WebServicesLdap_Obje
+ ts,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+description: Utilisateur du webservices contact
+cn: Utilisateurs_contacts_domaine1_WebServicesLdap
+objectclass: groupOfUniqueNames
+uniqueMember: uid=consultant_domaine_1,ou=Applitest,ou=Applications,o=insee,c=fr
+
+
+dn: cn=Admin_WebServicesLdap,ou=WebServicesLdap_Obje
+ ts,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+description: Utilisateur du webservices contact
+cn: Admin_WebServicesLdap
+objectclass: groupOfUniqueNames
+uniqueMember: uid=admin,ou=Applitest,ou=Applications,o=insee,c=fr
+
+dn: cn=Gestionnaires_contacts_domaine2_WebServicesLdap,ou=WebServicesLdap_Obje
+ ts,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+description: Utilisateur du webservices contact
+cn: Gestionnaires_contacts_domaine2_WebServicesLdap
+objectclass: groupOfUniqueNames
+uniqueMember: uid=gestionnaire_domaine_2,ou=Applitest,ou=Applications,o=insee,c=fr
+
+# DOMAINE DE GESTION 1
+dn: ou=clients_domaine1,o=insee,c=fr
+description: domaine de gestion des clients de diffusion sirene
+objectclass: top
+objectclass: organizationalUnit
+ou: clients_domaine1
+
+dn: ou=contacts,ou=clients_domaine1,o=insee,c=fr
+description: contact du domaine de gestion des clients diffusion sirene
+objectclass: top
+objectclass: organizationalUnit
+ou: contacts
+
+dn: ou=organisations,ou=clients_domaine1,o=insee,c=fr
+description: organisations du domaine de gestion des clients diffusion sirene
+objectclass: top
+objectclass: organizationalUnit
+ou: organisations
+
+dn: ou=adresses,ou=clients_domaine1,o=insee,c=fr
+objectclass: top
+objectclass: organizationalUnit
+ou: adresses
+description: domaine de gestion des adresses postales de réception des fichiers par les
+
+dn: uid=testc,ou=contacts,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeCompte
+objectClass: inseeContact
+objectClass: inseeAttributsAuthentification
+objectClass: inseeAttributsHabilitation
+objectClass: inseeAttributsCommunication
+inseeOrganisationDN: uid=testo,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+mail: test@test.fr
+uid: testc
+inseeAdressePostaleDN: l=testa,ou=adresses,ou=clients_domaine1,o=insee,c=fr
+telephoneNumber: 1209883940
+cn: Testy Test
+inseegroupedefaut: prop_role_applitest
+inseegroupedefaut: role2_applitest
+inseegroupedefaut: prop1_TestIgnoreCase_applitest
+inseegroupedefaut: Prop2_TestIgnoreCase_applitest
+
+dn: uid=byebye,ou=contacts,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeCompte
+objectClass: inseeContact
+objectClass: inseeAttributsAuthentification
+objectClass: inseeAttributsHabilitation
+objectClass: inseeAttributsCommunication
+uid: byebye
+cn: byebye
+
+dn: uid=asupprimer,ou=contacts,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeCompte
+objectClass: inseeContact
+objectClass: inseeAttributsAuthentification
+objectClass: inseeAttributsHabilitation
+objectClass: inseeAttributsCommunication
+inseeOrganisationDN: uid=testo,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+mail: test1@test.fr
+uid: asupprimer
+inseeAdressePostaleDN: l=testa,ou=adresses,ou=clients_domaine1,o=insee,c=fr
+telephoneNumber: 1209883940
+cn: Testy Test
+inseegroupedefaut: prop_role_applitest
+inseegroupedefaut: role2_applitest
+inseegroupedefaut: prop1_TestIgnoreCase_applitest
+inseegroupedefaut: Prop2_TestIgnoreCase_applitest
+
+dn: uid=agarder,ou=contacts,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeCompte
+objectClass: inseeContact
+objectClass: inseeAttributsAuthentification
+objectClass: inseeAttributsHabilitation
+objectClass: inseeAttributsCommunication
+inseeOrganisationDN: uid=testo,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+mail: test1@test.fr
+uid: agarder
+inseeAdressePostaleDN: l=testa,ou=adresses,ou=clients_domaine1,o=insee,c=fr
+telephoneNumber: 1209883940
+cn: Testy Test
+inseegroupedefaut: prop_role_applitest
+inseegroupedefaut: role2_applitest
+inseegroupedefaut: prop1_TestIgnoreCase_applitest
+inseegroupedefaut: Prop2_TestIgnoreCase_applitest
+
+dn: uid=testo,ou=contacts,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeCompte
+objectClass: inseeContact
+objectClass: inseeAttributsAuthentification
+objectClass: inseeAttributsHabilitation
+objectClass: inseeAttributsCommunication
+inseeOrganisationDN: uid=testo,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+mail: testo@test.fr
+uid: testo
+inseeAdressePostaleDN: l=testa,ou=adresses,ou=clients_domaine1,o=insee,c=fr
+telephoneNumber: 1209883940
+cn: Testy Test
+inseegroupedefaut: prop_role_applitest
+inseegroupedefaut: role2_applitest
+inseegroupedefaut: prop1_TestIgnoreCase_applitest
+inseegroupedefaut: Prop2_TestIgnoreCase_applitest
+
+dn: uid=testo,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeOrganisation
+uid: testo
+description: Insee
+
+dn: uid=testi,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeOrganisation
+uid: testi
+description: Autre
+
+dn: uid=asupprimer,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeOrganisation
+uid: asupprimer
+description: Autre
+
+dn: uid=amodifier,ou=organisations,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: inseeOrganisation
+uid: amodifier
+description: Autre
+
+dn: l=testa, ou=adresses,ou=clients_domaine1,o=insee,c=fr
+objectClass: top
+objectClass: locality
+objectClass: inseeAdressePostale
+l: testa
+inseeAdressePostaleCorrespondantLigne4: 88 AVE VERDIER
+inseeAdressePostaleCorrespondantLigne3: _
+inseeAdressePostaleCorrespondantLigne2: _
+inseeAdressePostaleCorrespondantLigne1: Insee
+inseeAdressePostaleCorrespondantLigne7: _
+inseeAdressePostaleCorrespondantLigne6: 92120 MONTROUGE
+inseeAdressePostaleCorrespondantLigne5: _
+
+
+# DOMAINE DE GESTION 2
+dn: ou=clients_domaine2,o=insee,c=fr
+description: domaine de gestion des clients de diffusion sirene
+objectclass: top
+objectclass: organizationalUnit
+ou: clients_domaine1
+
+dn: ou=contacts,ou=clients_domaine2,o=insee,c=fr
+description: contact du domaine de gestion des clients diffusion sirene
+objectclass: top
+objectclass: organizationalUnit
+ou: contacts
+
+dn: ou=organisations,ou=clients_domaine2,o=insee,c=fr
+description: organisations du domaine de gestion des clients diffusion sirene
+objectclass: top
+objectclass: organizationalUnit
+ou: organisations
+
+dn: ou=adresses,ou=clients_domaine2,o=insee,c=fr
+objectclass: top
+objectclass: organizationalUnit
+ou: adresses
+description: domaine de gestion des adresses postales de réception des fichiers par les
+
+
+# DOMAINE DE GESTION SSM
+dn: cn=Profil_SSM_WebServiceLdap,cn=profil-contact-WebServicesLdap,ou=We
+ bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+cn: Profil_SSM_WebServiceLdap
+objectclass: inseeOrganizationalRole
+inseepropriete: ldapUrl$localhost
+inseepropriete: ldapPort$10389
+inseepropriete: brancheContact$ou=SSM,o=insee,c=fr
+inseepropriete: objectclasscontact$top,person,organizationalPerson,inetOrgPerson,inseeAuthenticatedUser
+inseepropriete: branchesApplicativesPossibles$applitest
+description: SSM
+
+dn: ou=SSM,o=insee,c=fr
+description: domaine de gestion des SSM
+objectclass: top
+objectclass: organizationalUnit
+ou: SSM
+
+dn: uid=UTILISATEURSSM,ou=SSM,o=insee,c=fr
+uid: UTILISATEURSSM
+userPassword: {SHA}c3q3RSeNwMY7E09Ve9oBHw+MVXg=
+inseeGroupeDefaut: role_applicatif
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: inseeAuthenticatedUser
+cn: Alfred Dupont
+sn: Dupont
+givenName: Alfred
+mail: alfred.dupont@gouv.test
+description: utilisateur de test ssm
+
+dn: uid=Testd,ou=SSM,o=insee,c=fr
+uid: Testd
+userPassword: {SHA}c3q3RSeNwMY7E09Ve9oBHw+MVXg3=
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: inseeAuthenticatedUser
+cn: Dodo Dupont 2
+sn: Dupont 2
+givenName: Alfred2
+mail: alfred.dupont@gouv.test2
+description: utilisateur de test ssm
+inseeGroupeDefaut: role_applicatif
+inseegroupedefaut: prop_role_applitest
+inseegroupedefaut: role2_applitest
+inseegroupedefaut: prop1_TestIgnoreCase_applitest
+inseegroupedefaut: Prop2_TestIgnoreCase_applitest
+
+
+
+dn: uid=admin,ou=Applitest,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+objectclass: inseeApplication
+cn: admin
+sn: admin
+givenname: admin
+uid: admin
+userpassword: admin
+
+
+dn: uid=consultant_domaine_1,ou=Applitest,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+objectclass: inseeApplication
+cn: consultant_domaine_1
+sn: consultant_domaine_1
+givenname: consultant_domaine_1
+uid: consultant_domaine_1
+userpassword: consultant
+
+
+dn: uid=gestionnaire_domaine_2,ou=Applitest,ou=Applications,o=insee,c=fr
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+objectclass: inseeApplication
+cn: gestionnaire_domaine_2
+sn: gestionnaire_domaine_2
+givenname: gestionnaire_domaine_2
+uid: gestionnaire_domaine_2
+userpassword: gestionnaire

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/LdapUtils.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/LdapUtils.java
@@ -23,6 +23,8 @@ import fr.insee.sugoi.core.model.PageResult;
 import fr.insee.sugoi.core.model.PageableResult;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class LdapUtils {
 
@@ -72,6 +74,14 @@ public class LdapUtils {
       return LdapFilter.or(filters);
     }
     throw new RuntimeException("Impossible de determiner le type de la recherche");
+  }
+
+  public static Filter getFilterFromCriteria(Map<String, String> searchProperties) {
+    return LdapFilter.and(
+        searchProperties.keySet().stream()
+            .filter(key -> searchProperties.get(key) != null)
+            .map(key -> LdapFilter.contains(key, searchProperties.get(key)))
+            .collect(Collectors.toList()));
   }
 
   public static <T> void setResponseControls(PageResult<T> page, SearchResult searchResult) {

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/ApplicationLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/ApplicationLdapMapper.java
@@ -20,9 +20,9 @@ import fr.insee.sugoi.ldap.utils.mapper.properties.ApplicationLdap;
 import fr.insee.sugoi.model.Application;
 import java.util.List;
 
-public class ApplicationLdapMapper {
+public class ApplicationLdapMapper implements LdapMapper<Application> {
 
-  public static Application mapFromSearchEntry(SearchResultEntry searchResultEntry) {
+  public Application fromLdapToObject(SearchResultEntry searchResultEntry) {
     return GenericLdapMapper.transform(searchResultEntry, ApplicationLdap.class, Application.class);
   }
 

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/ApplicationLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/ApplicationLdapMapper.java
@@ -1,0 +1,37 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap.utils.mapper;
+
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.Modification;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+import fr.insee.sugoi.ldap.utils.mapper.properties.ApplicationLdap;
+import fr.insee.sugoi.model.Application;
+import java.util.List;
+
+public class ApplicationLdapMapper {
+
+  public static Application mapFromSearchEntry(SearchResultEntry searchResultEntry) {
+    return GenericLdapMapper.transform(searchResultEntry, ApplicationLdap.class, Application.class);
+  }
+
+  public static List<Attribute> mapToAttribute(Application application) {
+    return GenericLdapMapper.toAttribute(application, ApplicationLdap.class, Application.class);
+  }
+
+  public static List<Modification> createMods(Application updatedApplication) {
+    return GenericLdapMapper.createMods(
+        updatedApplication, ApplicationLdap.class, Application.class);
+  }
+}

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/GroupLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/GroupLdapMapper.java
@@ -22,10 +22,10 @@ import fr.insee.sugoi.model.Group;
 import java.util.List;
 
 @LdapObjectClass(values = {"top", "groupOfUniqueNames"})
-public class GroupLdapMapper {
+public class GroupLdapMapper implements LdapMapper<Group> {
 
-  public static Group mapFromSearchEntry(SearchResultEntry searchResultEntry) {
-    return GenericLdapMapper.transform(searchResultEntry, GroupLdap.class, Group.class);
+  public Group fromLdapToObject(SearchResultEntry entry) {
+    return GenericLdapMapper.transform(entry, GroupLdap.class, Group.class);
   }
 
   public static List<Attribute> mapToAttribute(Group group) {

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/GroupLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/GroupLdapMapper.java
@@ -1,0 +1,38 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap.utils.mapper;
+
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.Modification;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+import fr.insee.sugoi.ldap.utils.mapper.properties.GroupLdap;
+import fr.insee.sugoi.ldap.utils.mapper.properties.LdapObjectClass;
+import fr.insee.sugoi.model.Group;
+import java.util.List;
+
+@LdapObjectClass(values = {"top", "groupOfUniqueNames"})
+public class GroupLdapMapper {
+
+  public static Group mapFromSearchEntry(SearchResultEntry searchResultEntry) {
+    return GenericLdapMapper.transform(searchResultEntry, GroupLdap.class, Group.class);
+  }
+
+  public static List<Attribute> mapToAttribute(Group group) {
+    return GenericLdapMapper.toAttribute(group, GroupLdap.class, Group.class);
+  }
+
+  public static List<Modification> createMods(Group updatedGroup) {
+    return GenericLdapMapper.createMods(updatedGroup, GroupLdap.class, Group.class);
+  }
+}

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/LdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/LdapMapper.java
@@ -1,0 +1,21 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap.utils.mapper;
+
+import com.unboundid.ldap.sdk.SearchResultEntry;
+
+public interface LdapMapper<ResultType> {
+
+  public ResultType fromLdapToObject(SearchResultEntry entry);
+}

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/ModelType.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/ModelType.java
@@ -11,21 +11,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package fr.insee.sugoi.ldap.utils.mapper.properties.utils;
+package fr.insee.sugoi.ldap.utils.mapper;
 
-import fr.insee.sugoi.ldap.utils.mapper.ModelType;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
-public @interface MapToMapElement {
-  String name();
-
-  String key();
-
-  /** Type d'objet */
-  ModelType type() default ModelType.STRING;
+public enum ModelType {
+  STRING,
+  BYTES,
+  ORGANISATION
 }

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/OrganizationLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/OrganizationLdapMapper.java
@@ -20,9 +20,9 @@ import fr.insee.sugoi.ldap.utils.mapper.properties.OrganizationLdap;
 import fr.insee.sugoi.model.Organization;
 import java.util.List;
 
-public class OrganizationLdapMapper {
+public class OrganizationLdapMapper implements LdapMapper<Organization> {
 
-  public static Organization mapFromSearchEntry(SearchResultEntry searchResultEntry) {
+  public Organization fromLdapToObject(SearchResultEntry searchResultEntry) {
     Organization org =
         GenericLdapMapper.transform(searchResultEntry, OrganizationLdap.class, Organization.class);
     // org.setGpgkey(searchResultEntry.getAttribute("inseeClefChiffrement").getValueByteArray());

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/OrganizationLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/OrganizationLdapMapper.java
@@ -13,16 +13,28 @@
 */
 package fr.insee.sugoi.ldap.utils.mapper;
 
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.Modification;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import fr.insee.sugoi.ldap.utils.mapper.properties.OrganizationLdap;
 import fr.insee.sugoi.model.Organization;
+import java.util.List;
 
 public class OrganizationLdapMapper {
 
   public static Organization mapFromSearchEntry(SearchResultEntry searchResultEntry) {
     Organization org =
         GenericLdapMapper.transform(searchResultEntry, OrganizationLdap.class, Organization.class);
-    org.setGpgkey(searchResultEntry.getAttribute("inseeClefChiffrement").getValueByteArray());
+    // org.setGpgkey(searchResultEntry.getAttribute("inseeClefChiffrement").getValueByteArray());
     return org;
+  }
+
+  public static List<Attribute> mapToAttribute(Organization organization) {
+    return GenericLdapMapper.toAttribute(organization, OrganizationLdap.class, Organization.class);
+  }
+
+  public static List<Modification> createMods(Organization updatedOrganization) {
+    return GenericLdapMapper.createMods(
+        updatedOrganization, OrganizationLdap.class, Organization.class);
   }
 }

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/UserLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/UserLdapMapper.java
@@ -20,11 +20,11 @@ import fr.insee.sugoi.ldap.utils.mapper.properties.UserLdap;
 import fr.insee.sugoi.model.User;
 import java.util.List;
 
-public class UserLdapMapper {
+public class UserLdapMapper implements LdapMapper<User> {
 
-  public static User mapFromSearchEntry(SearchResultEntry searchResultEntry) {
-    User user = GenericLdapMapper.transform(searchResultEntry, UserLdap.class, User.class);
-    return user;
+  @Override
+  public User fromLdapToObject(SearchResultEntry searchResultEntry) {
+    return GenericLdapMapper.transform(searchResultEntry, UserLdap.class, User.class);
   }
 
   public static List<Attribute> mapToAttribute(User u) {

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/UserLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/UserLdapMapper.java
@@ -13,14 +13,25 @@
 */
 package fr.insee.sugoi.ldap.utils.mapper;
 
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.Modification;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import fr.insee.sugoi.ldap.utils.mapper.properties.UserLdap;
 import fr.insee.sugoi.model.User;
+import java.util.List;
 
 public class UserLdapMapper {
 
   public static User mapFromSearchEntry(SearchResultEntry searchResultEntry) {
     User user = GenericLdapMapper.transform(searchResultEntry, UserLdap.class, User.class);
     return user;
+  }
+
+  public static List<Attribute> mapToAttribute(User u) {
+    return GenericLdapMapper.toAttribute(u, UserLdap.class, User.class);
+  }
+
+  public static List<Modification> createMods(User updatedUser) {
+    return GenericLdapMapper.createMods(updatedUser, UserLdap.class, User.class);
   }
 }

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/ApplicationLdap.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/ApplicationLdap.java
@@ -1,0 +1,33 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap.utils.mapper.properties;
+
+import fr.insee.sugoi.ldap.utils.mapper.properties.utils.AttributeLdapName;
+import fr.insee.sugoi.ldap.utils.mapper.properties.utils.MapToAttribute;
+
+@LdapObjectClass(
+    values = {
+      "top",
+      "organizationalUnit",
+    })
+public class ApplicationLdap {
+
+  @MapToAttribute("name")
+  @AttributeLdapName("ou")
+  public String name;
+
+  @MapToAttribute("owner")
+  @AttributeLdapName("creatorsName")
+  public String owner;
+}

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/GroupLdap.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/GroupLdap.java
@@ -1,0 +1,28 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap.utils.mapper.properties;
+
+import fr.insee.sugoi.ldap.utils.mapper.properties.utils.AttributeLdapName;
+import fr.insee.sugoi.ldap.utils.mapper.properties.utils.MapToAttribute;
+
+public class GroupLdap {
+
+  @MapToAttribute("name")
+  @AttributeLdapName("cn")
+  public String name;
+
+  @MapToAttribute("description")
+  @AttributeLdapName("description")
+  public String description;
+}

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/LdapObjectClass.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/LdapObjectClass.java
@@ -11,21 +11,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package fr.insee.sugoi.ldap.utils.mapper.properties.utils;
+package fr.insee.sugoi.ldap.utils.mapper.properties;
 
-import fr.insee.sugoi.ldap.utils.mapper.ModelType;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
-public @interface MapToMapElement {
-  String name();
+@Target(ElementType.TYPE)
+public @interface LdapObjectClass {
 
-  String key();
-
-  /** Type d'objet */
-  ModelType type() default ModelType.STRING;
+  String[] values() default "top";
 }

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/OrganizationLdap.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/OrganizationLdap.java
@@ -17,11 +17,17 @@ import fr.insee.sugoi.ldap.utils.mapper.properties.utils.AttributeLdapName;
 import fr.insee.sugoi.ldap.utils.mapper.properties.utils.MapToAttribute;
 import fr.insee.sugoi.ldap.utils.mapper.properties.utils.MapToMapElement;
 
+@LdapObjectClass(
+    values = {
+      "top",
+      "inseeCompte",
+      "inseeOrganisation",
+    })
 public class OrganizationLdap {
 
-  @AttributeLdapName("cn")
+  @AttributeLdapName("uid")
   @MapToAttribute("identifiant")
-  public String cn;
+  public String uid;
 
   @AttributeLdapName("description")
   @MapToMapElement(name = "attributes", key = "description")

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/UserLdap.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/UserLdap.java
@@ -17,6 +17,15 @@ import fr.insee.sugoi.ldap.utils.mapper.properties.utils.AttributeLdapName;
 import fr.insee.sugoi.ldap.utils.mapper.properties.utils.MapToAttribute;
 import fr.insee.sugoi.ldap.utils.mapper.properties.utils.MapToMapElement;
 
+@LdapObjectClass(
+    values = {
+      "top",
+      "inseeCompte",
+      "inseeContact",
+      "inseeAttributsAuthentification",
+      "inseeAttributsHabilitation",
+      "inseeAttributsCommunication"
+    })
 public class UserLdap {
 
   @MapToAttribute("username")

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/utils/MapToAttribute.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/properties/utils/MapToAttribute.java
@@ -13,6 +13,7 @@
 */
 package fr.insee.sugoi.ldap.utils.mapper.properties.utils;
 
+import fr.insee.sugoi.ldap.utils.mapper.ModelType;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -24,4 +25,7 @@ public @interface MapToAttribute {
 
   /** Nom de l'attributLdap ce field. */
   String value();
+
+  /** Type d'objet */
+  ModelType type() default ModelType.STRING;
 }


### PR DESCRIPTION
This PR depends on #29 .
I'm not sure of this one. I tried refactoring the methods of LdapReaderStore and LdapWriterStore by creating a generic LdapMapper interface for mappers but I realized it was only useful for search methods.