### PR TITLE
57 manage user storages

### DIFF
--- a/sugoi-api-distribution/sugoi-api-distribution-full-env/src/main/resources/ldap-data/init-ldap.ldif
+++ b/sugoi-api-distribution/sugoi-api-distribution-full-env/src/main/resources/ldap-data/init-ldap.ldif
@@ -104,6 +104,23 @@ cn: Profil_domaine2_WebServiceLdap
 objectclass: inseeOrganizationalRole
 inseepropriete: ldapUrl$localhost
 inseepropriete: ldapPort$10389
+
+dn: cn=monUserStorage,cn=Profil_domaine2_WebServiceLdap,cn=profil-contact-WebServicesLdap,ou=We
+ bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+cn: monUserStorage
+objectclass: inseeOrganizationalRole
+inseepropriete: brancheContact$ou=contacts,ou=clients_domaine2,o=insee,c=fr
+inseepropriete: brancheAdresse$ou=adresses,ou=clients_domaine2,o=insee,c=fr
+inseepropriete: brancheOrganisation$ou=organisations,ou=clients_domaine2,o=in
+ see,c=fr
+inseepropriete: groupSourcePattern$ou={appliname}_Objets,ou={appliname},ou=Applications,o=insee,c=fr
+inseepropriete: groupFilterPattern$(cn={group}_{appliname})
+description: domaine2
+
+dn: cn=autreUserStorage,cn=Profil_domaine2_WebServiceLdap,cn=profil-contact-WebServicesLdap,ou=We
+ bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
+cn: autreUserStorage
+objectclass: inseeOrganizationalRole
 inseepropriete: brancheContact$ou=contacts,ou=clients_domaine2,o=insee,c=fr
 inseepropriete: brancheAdresse$ou=adresses,ou=clients_domaine2,o=insee,c=fr
 inseepropriete: brancheOrganisation$ou=organisations,ou=clients_domaine2,o=in

--- a/sugoi-api-file-config-provider/src/test/java/fr/insee/sugoi/config/file/LocalFileRealmProviderDAO_realmsOneTest.java
+++ b/sugoi-api-file-config-provider/src/test/java/fr/insee/sugoi/config/file/LocalFileRealmProviderDAO_realmsOneTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
 import fr.insee.sugoi.core.realm.RealmProvider;
+import fr.insee.sugoi.model.Realm;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,5 +47,18 @@ public class LocalFileRealmProviderDAO_realmsOneTest {
   public void shouldFetchTestRealm() {
     assertThat("We should have a realm test", localFileConfig.load("test").getName(), is("test"));
     assertThat("We should have a realm TeSt", localFileConfig.load("TeSt").getName(), is("test"));
+  }
+
+  @Test
+  public void shouldHaveTwoUserstorages() {
+    Realm realm = localFileConfig.load("test");
+    assertThat(
+        "We should have a userstorage default",
+        realm.getUserStorages().stream()
+            .anyMatch(userstorage -> userstorage.getName().equals("default")));
+    assertThat(
+        "We should have a userstorage other",
+        realm.getUserStorages().stream()
+            .anyMatch(userstorage -> userstorage.getName().equals("other")));
   }
 }

--- a/sugoi-api-file-config-provider/src/test/resources/realms-one.json
+++ b/sugoi-api-file-config-provider/src/test/resources/realms-one.json
@@ -11,6 +11,14 @@
                 "properties": null,
                 "readerType": null,
                 "writerType": null
+            },
+            {
+                "name": "other",
+                "userSource": "/users",
+                "organizationSource": "/organizations2",
+                "properties": null,
+                "readerType": null,
+                "writerType": null
             }
         ]
     }

--- a/sugoi-api-ldap-config-provider/pom.xml
+++ b/sugoi-api-ldap-config-provider/pom.xml
@@ -22,5 +22,27 @@
          <groupId>fr.insee.sugoi</groupId>
          <artifactId>sugoi-api-ldap-utils</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-data-ldap</artifactId>
+         <scope>test</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>org.springframework.boot</groupId>
+               <artifactId>spring-boot-starter-logging</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-test</artifactId>
+         <scope>test</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>org.springframework.boot</groupId>
+               <artifactId>spring-boot-starter-logging</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
    </dependencies>
 </project>

--- a/sugoi-api-ldap-config-provider/src/test/java/fr/insee/sugoi/config/LdapRealmProviderDAOTest.java
+++ b/sugoi-api-ldap-config-provider/src/test/java/fr/insee/sugoi/config/LdapRealmProviderDAOTest.java
@@ -1,0 +1,66 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.config;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import fr.insee.sugoi.model.Realm;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ldap.embedded.EmbeddedLdapAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {EmbeddedLdapAutoConfiguration.class, LdapRealmProviderDAOImpl.class})
+@TestPropertySource(locations = "classpath:/application.properties")
+public class LdapRealmProviderDAOTest {
+
+  @Autowired LdapRealmProviderDAOImpl ldapRealmProviderDAOImpl;
+
+  @Test
+  public void loadUniStorage() {
+    Realm realm = ldapRealmProviderDAOImpl.load("domaine1");
+    assertThat("Should have appSource", realm.getAppSource(), is("applitest"));
+    assertThat(
+        "Default userstorage should have usersource",
+        realm.getUserStorages().get(0).getUserSource(),
+        is("ou=contacts,ou=clients_domaine1,o=insee,c=fr"));
+  }
+
+  @Test
+  public void loadMultiStorage() {
+    Realm realm = ldapRealmProviderDAOImpl.load("domaine2");
+    assertThat("Should have two userstorages", realm.getUserStorages().size(), is(2));
+    assertThat(
+        "First userstorage is monUserStorage",
+        realm.getUserStorages().get(1).getName(),
+        is("monUserStorage"));
+    assertThat(
+        "Second userstorage is autreUserStorage",
+        realm.getUserStorages().get(0).getName(),
+        is("autreUserStorage"));
+  }
+
+  @Test
+  public void findAllStorages() {
+    List<Realm> realms = ldapRealmProviderDAOImpl.findAll();
+    assertThat("Should have three realm", realms.size(), is(3));
+    assertThat(
+        "Should have userstorages",
+        realms.get(1).getUserStorages().get(0).getName(),
+        is("autreUserStorage"));
+  }
+}

--- a/sugoi-api-ldap-config-provider/src/test/resources/application.properties
+++ b/sugoi-api-ldap-config-provider/src/test/resources/application.properties
@@ -1,0 +1,11 @@
+
+spring.ldap.embedded.base-dn=o=insee,c=fr
+spring.ldap.embedded.ldif=classpath:ldap.ldif
+spring.ldap.embedded.validation.enabled=false
+spring.ldap.embedded.port=10389
+spring.ldap.embedded.credential.password=password
+spring.ldap.embedded.credential.username=cn=admin,o=insee,c=fr
+
+fr.insee.sugoi.config.ldap.profils.port=10389
+fr.insee.sugoi.config.ldap.profils.branche=cn=profil-contact-WebServicesLdap,ou=WebServicesLdap_Objets,ou=WebServicesLdap,ou=applications,o=insee,c=fr
+fr.insee.sugoi.realm.config.type=ldap

--- a/sugoi-api-ldap-config-provider/src/test/resources/ldap.ldif
+++ b/sugoi-api-ldap-config-provider/src/test/resources/ldap.ldif
@@ -105,13 +105,13 @@ dn: cn=Profil_domaine2_WebServiceLdap,cn=profil-contact-WebServicesLdap,ou=We
  bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
 cn: Profil_domaine2_WebServiceLdap
 objectclass: inseeOrganizationalRole
+inseepropriete: ldapUrl$localhost
+inseepropriete: ldapPort$10389
 
 dn: cn=monUserStorage,cn=Profil_domaine2_WebServiceLdap,cn=profil-contact-WebServicesLdap,ou=We
  bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
 cn: monUserStorage
 objectclass: inseeOrganizationalRole
-inseepropriete: ldapUrl$localhost
-inseepropriete: ldapPort$10389
 inseepropriete: brancheContact$ou=contacts,ou=clients_domaine2,o=insee,c=fr
 inseepropriete: brancheAdresse$ou=adresses,ou=clients_domaine2,o=insee,c=fr
 inseepropriete: brancheOrganisation$ou=organisations,ou=clients_domaine2,o=in
@@ -124,8 +124,6 @@ dn: cn=autreUserStorage,cn=Profil_domaine2_WebServiceLdap,cn=profil-contact-WebS
  bServicesLdap_Objets,ou=WebServicesLdap,ou=Applications,o=insee,c=fr
 cn: autreUserStorage
 objectclass: inseeOrganizationalRole
-inseepropriete: ldapUrl$localhost
-inseepropriete: ldapPort$10389
 inseepropriete: brancheContact$ou=contacts,ou=clients_domaine2,o=insee,c=fr
 inseepropriete: brancheAdresse$ou=adresses,ou=clients_domaine2,o=insee,c=fr
 inseepropriete: brancheOrganisation$ou=organisations,ou=clients_domaine2,o=in

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/RealmLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/RealmLdapMapper.java
@@ -15,17 +15,12 @@ package fr.insee.sugoi.ldap.utils.mapper;
 
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import fr.insee.sugoi.model.Realm;
-import fr.insee.sugoi.model.UserStorage;
-import java.util.List;
-import org.springframework.stereotype.Component;
 
 /** ProfilContextMapper */
-@Component
 public class RealmLdapMapper {
 
-  public Realm mapFromSearchEntry(SearchResultEntry searchResultEntry) {
+  public static Realm mapFromSearchEntry(SearchResultEntry searchResultEntry) {
     Realm realm = new Realm();
-    UserStorage userStorage = new UserStorage();
     realm.setName(searchResultEntry.getAttributeValue("cn").split("_")[1]);
     String[] inseeProperties = searchResultEntry.getAttributeValues("inseepropriete");
     for (String inseeProperty : inseeProperties) {
@@ -38,26 +33,8 @@ public class RealmLdapMapper {
         if (property[0].contains("branchesApplicativesPossibles")) {
           realm.setAppSource(property[1]);
         }
-
-        if (property[0].contains("brancheContact")) {
-          userStorage.setUserSource(property[1]);
-        }
-        if (property[0].equals("brancheOrganisation")) {
-          userStorage.setOrganizationSource(property[1]);
-        }
-        if (property[0].equals("brancheAdresse")) {
-          userStorage.setAddressSource(property[1]);
-        }
-        if (property[0].equals("groupSourcePattern")) {
-          userStorage.addProperty("group_source_pattern", property[1]);
-        }
-        if (property[0].equals("groupFilterPattern")) {
-          userStorage.addProperty("group_filter_pattern", property[1]);
-        }
       }
     }
-    userStorage.setName("default");
-    realm.setUserStorages(List.of(userStorage));
     return realm;
   }
 }

--- a/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/UserStorageLdapMapper.java
+++ b/sugoi-api-ldap-utils/src/main/java/fr/insee/sugoi/ldap/utils/mapper/UserStorageLdapMapper.java
@@ -1,0 +1,59 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap.utils.mapper;
+
+import com.unboundid.ldap.sdk.Attribute;
+import fr.insee.sugoi.model.UserStorage;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class UserStorageLdapMapper {
+
+  public static UserStorage mapFromAttributes(Collection<Attribute> attributes) {
+    UserStorage userStorage = new UserStorage();
+    attributes.stream()
+        .filter(attribute -> attribute.getName().equals("inseepropriete"))
+        .forEach(
+            attribute -> {
+              for (String value : attribute.getValues()) {
+                String[] property = value.split("\\$");
+                if (property.length == 2) {
+                  if (property[0].contains("brancheContact")) {
+                    userStorage.setUserSource(property[1]);
+                  }
+                  if (property[0].equals("brancheOrganisation")) {
+                    userStorage.setOrganizationSource(property[1]);
+                  }
+                  if (property[0].equals("brancheAdresse")) {
+                    userStorage.setAddressSource(property[1]);
+                  }
+                  if (property[0].equals("groupSourcePattern")) {
+                    userStorage.addProperty("group_source_pattern", property[1]);
+                  }
+                  if (property[0].equals("groupFilterPattern")) {
+                    userStorage.addProperty("group_filter_pattern", property[1]);
+                  }
+                }
+              }
+            });
+    String name =
+        attributes.stream()
+            .filter(attribute -> attribute.getName().equals("cn"))
+            .collect(Collectors.toList())
+            .get(0)
+            .getValue();
+    userStorage.setName(name);
+    return userStorage;
+  }
+}

--- a/sugoi-api-ldap-utils/src/test/java/fr/insee/sugoi/ldap/utils/mapper/UserStorageLdapMapperTest.java
+++ b/sugoi-api-ldap-utils/src/test/java/fr/insee/sugoi/ldap/utils/mapper/UserStorageLdapMapperTest.java
@@ -1,0 +1,71 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package fr.insee.sugoi.ldap.utils.mapper;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import com.unboundid.ldap.sdk.Attribute;
+import fr.insee.sugoi.model.UserStorage;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = UserStorageLdapMapper.class)
+public class UserStorageLdapMapperTest {
+
+  UserStorageLdapMapper userStorageLdapMapper = new UserStorageLdapMapper();
+
+  @BeforeEach
+  public void setup() {}
+
+  @Test
+  public void getUserStorageObjectFromAttributes() {
+    String[] values = {
+      "brancheContact$ou=contacts,ou=clients_domaine1,o=insee,c=fr",
+      "brancheAdresse$ou=adresses,ou=clients_domaine1,o=insee,c=fr",
+      "brancheOrganisation$ou=organisations,ou=clients_domaine1,o=insee,c=fr",
+      "groupSourcePattern$ou={appliname}_Objets,ou={appliname},ou=Applications,o=insee,c=fr",
+      "groupFilterPattern$(cn={group}_{appliname})"
+    };
+    Attribute brancheContactAttribute = new Attribute("inseepropriete", values);
+    Attribute cnAttribute = new Attribute("cn", "userStorageName");
+    Collection<Attribute> attributes = new ArrayList<>();
+    attributes.add(cnAttribute);
+    attributes.add(brancheContactAttribute);
+    UserStorage userStorage = UserStorageLdapMapper.mapFromAttributes(attributes);
+    assertThat(
+        "Should have userSource",
+        userStorage.getUserSource(),
+        is("ou=contacts,ou=clients_domaine1,o=insee,c=fr"));
+    assertThat(
+        "Should have addressSource",
+        userStorage.getAddressSource(),
+        is("ou=adresses,ou=clients_domaine1,o=insee,c=fr"));
+    assertThat(
+        "Should have organizationSource",
+        userStorage.getOrganizationSource(),
+        is("ou=organisations,ou=clients_domaine1,o=insee,c=fr"));
+    assertThat(
+        "Should have group source pattern",
+        userStorage.getProperties().get("group_source_pattern"),
+        is("ou={appliname}_Objets,ou={appliname},ou=Applications,o=insee,c=fr"));
+    assertThat(
+        "Should have group filter pattern",
+        userStorage.getProperties().get("group_filter_pattern"),
+        is("(cn={group}_{appliname})"));
+  }
+}


### PR DESCRIPTION
With Ldap configuration if a realm profile has subordinates they will be parsed as UserStorage. Otherwise a unique UserStorage will be taken from the realm profile itself.