### PR TITLE
[ENH] :sparkles: Store certificate fingerprint without prefix in `inseePropriete`

### DIFF
--- a/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapWriterStore.java
+++ b/sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapWriterStore.java
@@ -785,15 +785,10 @@ public class LdapWriterStore extends LdapStore implements WriterStore {
         ldapPoolConnection.modify(
             new ModifyRequest(
                 getUserDN(user.getUsername()),
-                List.of(
-                    new Modification(
-                        ModificationType.DELETE,
-                        "usercertificate;binary",
-                        certificate.getEncoded()),
-                    new Modification(
-                        ModificationType.DELETE,
-                        "inseePropriete",
-                        "certificateId$" + certificateId))));
+                new Modification(
+                    ModificationType.DELETE, "usercertificate;binary", certificate.getEncoded())));
+        deleteInseeProprieteValueIfPresent(user.getUsername(), "certificateId$" + certificateId);
+        deleteInseeProprieteValueIfPresent(user.getUsername(), certificateId);
       }
 
       X509Certificate certificate = cfs.getCertificateFromByte(bytes);
@@ -805,7 +800,10 @@ public class LdapWriterStore extends LdapStore implements WriterStore {
                   new Modification(
                       ModificationType.ADD, "usercertificate;binary", certificate.getEncoded()),
                   new Modification(
-                      ModificationType.ADD, "inseePropriete", "certificateId$" + certificateId))));
+                      ModificationType.ADD,
+                      "inseePropriete",
+                      "certificateId$" + certificateId,
+                      certificateId))));
       ProviderResponse response = new ProviderResponse();
       response.setStatus(ProviderResponseStatus.OK);
       response.setEntityId(user.getUsername());
@@ -826,15 +824,10 @@ public class LdapWriterStore extends LdapStore implements WriterStore {
         ldapPoolConnection.modify(
             new ModifyRequest(
                 getUserDN(user.getUsername()),
-                List.of(
-                    new Modification(
-                        ModificationType.DELETE,
-                        "usercertificate;binary",
-                        certificate.getEncoded()),
-                    new Modification(
-                        ModificationType.DELETE,
-                        "inseePropriete",
-                        "certificateId$" + certificateId))));
+                new Modification(
+                    ModificationType.DELETE, "usercertificate;binary", certificate.getEncoded())));
+        deleteInseeProprieteValueIfPresent(user.getUsername(), "certificateId$" + certificateId);
+        deleteInseeProprieteValueIfPresent(user.getUsername(), certificateId);
         ProviderResponse response = new ProviderResponse();
         response.setStatus(ProviderResponseStatus.OK);
         response.setEntityId(user.getUsername());
@@ -847,6 +840,24 @@ public class LdapWriterStore extends LdapStore implements WriterStore {
     response.setStatus(ProviderResponseStatus.OK);
     response.setEntityId(user.getUsername());
     return response;
+  }
+
+  /**
+   * Delete a value from inseePropriete, tolerating the case where it is not present (e.g. a
+   * certificate added before this value was introduced, or already removed).
+   */
+  private void deleteInseeProprieteValueIfPresent(String username, String value)
+      throws LDAPException {
+    try {
+      ldapPoolConnection.modify(
+          new ModifyRequest(
+              getUserDN(username),
+              new Modification(ModificationType.DELETE, "inseePropriete", value)));
+    } catch (LDAPException e) {
+      if (!e.getResultCode().equals(ResultCode.NO_SUCH_ATTRIBUTE)) {
+        throw e;
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
**Description**

Closes #988

Keycloak's X.509 authentication module needs to look up a user from the raw SHA-256 fingerprint of the presented certificate, without knowing or reconstructing the existing `certificateId$` prefix used in `inseePropriete`.

This PR adds the plain fingerprint `<fingerprint>` as a second value of the multivalued `inseePropriete` attribute, alongside the existing `certificateId$<fingerprint>` value:

- `updateUserCertificate`: adds both values when a new certificate is set, and deletes both values (old fingerprint) when replacing an existing certificate.
- `deleteUserCertificate`: deletes both values when removing a certificate.

**Scope**

- `sugoi-api-ldap-store-provider/src/main/java/fr/insee/sugoi/store/ldap/LdapWriterStore.java`

**Out of scope**

- No new configuration key added, no documentation update needed.
- No test added (none existed previously for these methods).

**Checklist**

- [x] Linked to an issue (#988)
- [x] `mvn spotless:apply` applied
- [x] Commits signed-off (DCO)
- [ ] Tests updated/created *(not applicable — no prior test coverage)*
